### PR TITLE
Fix Navbar hover border layout shift

### DIFF
--- a/src/navigation/Navbar.tsx
+++ b/src/navigation/Navbar.tsx
@@ -83,7 +83,7 @@ const Navbar = () => {
           <a
             href="https://app.dugassistant.com"
             target="_blank"
-            className="relative rounded-md border-2 border-back-100 px-6 py-2 text-[13px] font-medium text-back-100 shadow-sm shadow-primary-400 hover:border-none hover:bg-black hover:text-primary-500 dark:border-white dark:bg-back-100/10 dark:text-white"
+            className="relative rounded-md border-2 border-back-100 px-6 py-2 text-[13px] font-medium text-back-100 shadow-sm shadow-primary-400 transition-all duration-300 ease-in-out hover:border-transparent hover:bg-black hover:text-primary-500 dark:border-white dark:bg-back-100/10 dark:text-white dark:hover:border-transparent"
           >
             <span>Se connecter</span>
           </a>


### PR DESCRIPTION
- Fixes the layout shift issue in the Navbar when hovering over the `Se connecter` link. The hover effect now uses `hover:border-transparent` instead of `hover:border-none` to maintain the layout without causing any shifting.

### Before

https://github.com/user-attachments/assets/f53abe19-3699-4ae3-8924-b3a513d7848f

### After

https://github.com/user-attachments/assets/dfb7339e-1bf0-4a7e-b46a-9d9c7361dff9

